### PR TITLE
Fix latest WK

### DIFF
--- a/src/atlas.js
+++ b/src/atlas.js
@@ -34,14 +34,14 @@ function generateAtlasMappingForLayer(activeDoc, layer) {
   const width = activeDoc.width;
 
   const atlasMappingTemplate = blah();
+  const uv = atlasMappingTemplate.clippingRectInUVCoords;
+  
+  uv.Bottom = layer.bounds.bottom / height;
+  uv.Left = layer.bounds.left / width;
+  uv.Right = layer.bounds.right / width;
+  uv.Top = layer.bounds.top / height;
 
-  atlasMappingTemplate.Properties.clippingRectInUVCoords.Properties = {
-    Bottom: layer.bounds.bottom / height,
-    Left: layer.bounds.left / width,
-    Right: layer.bounds.right / width,
-    Top: layer.bounds.top / height,
-  };
-  atlasMappingTemplate.Properties.partName = slugify(layer.name);
+  atlasMappingTemplate.partName = slugify(layer.name);
 
   return atlasMappingTemplate;
 }

--- a/src/atlas.js
+++ b/src/atlas.js
@@ -7,15 +7,12 @@ function generateAtlasJson(activeDoc, depotPath, depotPath1080p) {
   const atlasTemplate = inkAtlasTemplate();
   const atlasMappings = generateAtlasMappings(activeDoc);
 
-  atlasTemplate.Data.RootChunk.Properties.slots.Elements[0].Properties.texture.DepotPath =
-    depotPath;
-  atlasTemplate.Data.RootChunk.Properties.slots.Elements[1].Properties.texture.DepotPath =
+  atlasTemplate.Data.RootChunk.slots.Elements[0].texture.DepotPath = depotPath;
+  atlasTemplate.Data.RootChunk.slots.Elements[1].texture.DepotPath =
     depotPath1080p;
 
-  atlasTemplate.Data.RootChunk.Properties.slots.Elements[0].Properties.parts =
-    atlasMappings;
-  atlasTemplate.Data.RootChunk.Properties.slots.Elements[1].Properties.parts =
-    atlasMappings;
+  atlasTemplate.Data.RootChunk.slots.Elements[0].parts = atlasMappings;
+  atlasTemplate.Data.RootChunk.slots.Elements[1].parts = atlasMappings;
 
   return atlasTemplate;
 }

--- a/src/templates.js
+++ b/src/templates.js
@@ -9,11 +9,14 @@ const blah = function () {
 };
 
 const _inkAtlasTemplate = {
-  WolvenKitVersion: "8.8.1",
-  WKitJsonVersion: "0.0.3",
-  ExportedDateTime: "2022-01-25T19:03:40.1193136Z",
-  DataType: "CR2W",
-  ArchiveFileName: "",
+  Header: {
+    WolvenKitVersion: "8.8.1",
+    WKitJsonVersion: "0.0.3",
+    GameVersion: 1610,
+    ExportedDateTime: "2022-01-25T19:03:40.1193136Z",
+    DataType: "CR2W",
+    ArchiveFileName: "",
+  },
   Data: {
     Version: 195,
     BuildVersion: 0,

--- a/src/templates.js
+++ b/src/templates.js
@@ -9,31 +9,28 @@ const blah = function () {
 };
 
 const _inkAtlasTemplate = {
-  WolvenKitVersion: "8.5.0",
-  WKitJsonVersion: "0.0.1",
+  WolvenKitVersion: "8.8.1",
+  WKitJsonVersion: "0.0.3",
   ExportedDateTime: "2022-01-25T19:03:40.1193136Z",
+  DataType: "CR2W",
   ArchiveFileName: "",
   Data: {
+    Version: 195,
+    BuildVersion: 0,
     RootChunk: {
-      Type: "inkTextureAtlas",
-      Id: "1",
-      Properties: {
-        activeTexture: "StaticTexture",
-        cookingPlatform: "PLATFORM_PC",
-        dynamicTexture: {
-          DepotPath: null,
+      $type: "inkTextureAtlas",
+      activeTexture: "StaticTexture",
+      cookingPlatform: "PLATFORM_PC",
+      dynamicTexture: {
+        DepotPath: 0,
+        Flags: "Default",
+      },
+      dynamicTextureSlot: {
+        $type: "inkDynamicTextureSlot",
+        parts: [],
+        texture: {
+          DepotPath: 0,
           Flags: "Default",
-        },
-        dynamicTextureSlot: {
-          Type: "inkDynamicTextureSlot",
-          Id: "2",
-          Properties: {
-            parts: [],
-            texture: {
-              DepotPath: null,
-              Flags: "Default",
-            },
-          },
         },
         isSingleTextureMode: 1,
         parts: [],
@@ -42,45 +39,36 @@ const _inkAtlasTemplate = {
           Size: 3,
           Elements: [
             {
-              Type: "inkTextureSlot",
-              Id: "3",
-              Properties: {
-                parts: [],
-                slices: [],
-                texture: {
-                  DepotPath: "",
-                  Flags: "Default",
-                },
+              $type: "inkTextureSlot",
+              parts: [],
+              slices: [],
+              texture: {
+                DepotPath: "",
+                Flags: "Default",
               },
             },
             {
-              Type: "inkTextureSlot",
-              Id: "7",
-              Properties: {
-                parts: [],
-                slices: [],
-                texture: {
-                  DepotPath: "",
-                  Flags: "Default",
-                },
+              $type: "inkTextureSlot",
+              parts: [],
+              slices: [],
+              texture: {
+                DepotPath: "",
+                Flags: "Default",
               },
             },
             {
-              Type: "inkTextureSlot",
-              Id: "11",
-              Properties: {
-                parts: [],
-                slices: [],
-                texture: {
-                  DepotPath: null,
-                  Flags: "Default",
-                },
+              $type: "inkTextureSlot",
+              parts: [],
+              slices: [],
+              texture: {
+                DepotPath: 0,
+                Flags: "Default",
               },
             },
           ],
         },
         texture: {
-          DepotPath: null,
+          DepotPath: 0,
           Flags: "Default",
         },
         textureResolution: "UltraHD_3840_2160",
@@ -91,19 +79,16 @@ const _inkAtlasTemplate = {
 };
 
 const _atlasMappingTemplate = {
-  Type: "inkTextureAtlasMapper",
-  Properties: {
-    clippingRectInPixels: {
-      Type: "Rect",
-      Properties: {
-        bottom: 0,
-        left: 0,
-        right: 0,
-        top: 0,
-      },
-    },
-    clippingRectInUVCoords: {
-      Type: "RectF"
-    }
+  $type: "inkTextureAtlasMapper",
+  clippingRectInPixels: {
+    $type: "Rect",
+    bottom: 0,
+    left: 0,
+    right: 0,
+    top: 0,
   },
+  clippingRectInUVCoords: {
+    $type: "RectF",
+  },
+  partName: "",
 };

--- a/src/templates.js
+++ b/src/templates.js
@@ -32,47 +32,47 @@ const _inkAtlasTemplate = {
           DepotPath: 0,
           Flags: "Default",
         },
-        isSingleTextureMode: 1,
-        parts: [],
-        slices: [],
-        slots: {
-          Size: 3,
-          Elements: [
-            {
-              $type: "inkTextureSlot",
-              parts: [],
-              slices: [],
-              texture: {
-                DepotPath: "",
-                Flags: "Default",
-              },
-            },
-            {
-              $type: "inkTextureSlot",
-              parts: [],
-              slices: [],
-              texture: {
-                DepotPath: "",
-                Flags: "Default",
-              },
-            },
-            {
-              $type: "inkTextureSlot",
-              parts: [],
-              slices: [],
-              texture: {
-                DepotPath: 0,
-                Flags: "Default",
-              },
-            },
-          ],
-        },
-        texture: {
-          DepotPath: 0,
-          Flags: "Default",
-        },
-        textureResolution: "UltraHD_3840_2160",
       },
+      isSingleTextureMode: 1,
+      parts: [],
+      slices: [],
+      slots: {
+        Size: 3,
+        Elements: [
+          {
+            $type: "inkTextureSlot",
+            parts: [],
+            slices: [],
+            texture: {
+              DepotPath: "",
+              Flags: "Soft",
+            },
+          },
+          {
+            $type: "inkTextureSlot",
+            parts: [],
+            slices: [],
+            texture: {
+              DepotPath: "",
+              Flags: "Soft",
+            },
+          },
+          {
+            $type: "inkTextureSlot",
+            parts: [],
+            slices: [],
+            texture: {
+              DepotPath: 0,
+              Flags: "Default",
+            },
+          },
+        ],
+      },
+      texture: {
+        DepotPath: 0,
+        Flags: "Default",
+      },
+      textureResolution: "UltraHD_3840_2160",
     },
     EmbeddedFiles: [],
   },


### PR DESCRIPTION
Hey ! Thanks for this plugin it's a real time saver :)

I'm currently on WKit 8.8.1 and WKitJsonVersion has been updated to 0.0.3.
It breaks the .inkatlas generation because the format is slightly different.

I did the fix already but got stuck on how to be able to test locally.

So far I tried creating a dummy Adobe Photoshop Plugin in the Adobe Console, updated your manifest to match it and ran it locally but for some reason nothing appear on screen. So I added the permissions (latest [Manifest V5 requirement](https://developer.adobe.com/photoshop/uxp/2022/guides/uxp_guide/uxp-misc/manifest-v5/#plugin-permissions)) with e.g. `"localFileSystem": "fullAccess"` but still nothing showing up. I'd really like to test it first to make sure I didn't forget anything, if ever it rings a bell to you ?