### PR TITLE
Add option to flip image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /node_modules
 /dist
+/.vscode

--- a/src/export.js
+++ b/src/export.js
@@ -5,7 +5,7 @@ import { showAlert } from "./utils";
 
 export { executeExport };
 
-async function executeExport(file, scaleFactor) {
+async function executeExport(file, scaleFactor, flipImage = false) {
   const fs = storage.localFileSystem;
   const saveFile = await fs.createSessionToken(file);
   const activeDoc = app.activeDocument;
@@ -110,6 +110,24 @@ async function executeExport(file, scaleFactor) {
       ],
     },
   ];
+  if (flipImage) {
+    const flipAction = {
+      _obj: "flip",
+      _target: [
+        {
+          _enum: "ordinal",
+          _ref: "document",
+          _value: "first",
+        },
+      ],
+      axis: {
+        _enum: "orientation",
+        _value: "vertical",
+      },
+    };
+    let idx = batchPlayAction.findIndex(({ _obj }) => _obj == "imageSize");
+    batchPlayAction.splice(idx + 1, 0, flipAction);
+  }
 
   await core.executeAsModal(
     async (executionContext) => {

--- a/src/index.html
+++ b/src/index.html
@@ -72,6 +72,7 @@
         >Scale To (Percentage)</sp-label
       >
     </sp-textfield>
+    <sp-checkbox id="flipImage" width="100%">Flip image</sp-checkbox>
     Tip: Due to a limitation with Photoshop's API This will modify the current
     document. You can simply undo the export step to retrieve the document
     before you exported it.

--- a/src/index.js
+++ b/src/index.js
@@ -12,7 +12,7 @@ async function fitLayers(spacing) {
   fitLayersAndMove(spacing);
 }
 
-async function writeTgaFile(scaleFactor) {
+async function writeTgaFile(scaleFactor, flipImage) {
   const fs = storage.localFileSystem;
   const file = await fs.getFileForSaving("output", {
     types: ["tga"],
@@ -21,7 +21,7 @@ async function writeTgaFile(scaleFactor) {
     // file picker was cancelled
     return;
   }
-  executeExport(file, scaleFactor);
+  executeExport(file, scaleFactor, flipImage);
 }
 
 // Generate the atlas file and write
@@ -166,7 +166,8 @@ document.querySelector("#btnRedscript").addEventListener("click", (evt) => {
 
 document.querySelector("#btnExport").addEventListener("click", (evt) => {
   const scaleFactor = parseFloat(document.querySelector("#scaleFactor").value);
-  writeTgaFile(scaleFactor);
+  const flipImage = document.querySelector("#flipImage").checked;
+  writeTgaFile(scaleFactor, flipImage);
   evt.stopImmediatePropagation();
 });
 


### PR DESCRIPTION
The other day while browsing WolvenKit Asset browser I also noticed some flipped .xbm,
so I realized I might have done a mistake to remove it for all.
This PR add an additional checkbox (unchecked by default) that let the user chooses.

Currently waiting on:

- [ ] #14 